### PR TITLE
Use package schema 2.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,20 +1,16 @@
 {
-    "schema_version": "1.0",
+    "schema_version": "2.0",
     "packages": [
         {
             "name": "InputHelper",
-            "description": "Open new input form to input text using IMEs like SCIM,ibus. Temporarily solve input problem on Linux.",
             "author": "Anh Tu Nguyen <xgenvn@gmail.com>",
-            "homepage": "https://github.com/xgenvn/InputHelper",
-            "last_modified": "2012-07-17 10:55:22",
-            "platforms": {
-                "linux": [
-                    {
-                        "version": "1.0.0",
-                        "url": "https://nodeload.github.com/xgenvn/InputHelper/zipball/v1.0"
-                    }
-                ]
-            }
+            "details": "https://github.com/xgenvn/InputHelper",
+            "releases": [
+                {
+                    "sublime_text": "*",
+                    "details": "https://github.com/xgenvn/InputHelper/tags"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
This makes your plugin installable on ST3 (which it seems to work on).

Also, you **haven't pushed a tag in 2 years**. Remember that Package Control looks out for these tags when installing it on a machine.

In order for PC to grab your tag, it must be a valid [semver](http://semver.org). You may optionally use a leading `v`. If you forget to add a tag, Package Control will never see your release!
